### PR TITLE
Include CRUD log

### DIFF
--- a/ShareBook/ShareBook.Api/Controllers/AccountController.cs
+++ b/ShareBook/ShareBook.Api/Controllers/AccountController.cs
@@ -31,7 +31,7 @@ namespace ShareBook.Api.Controllers
             var result = _userService.AuthenticationByEmailAndPassword(user);
 
             if (result.Success)
-                return  _signManager.GenerateTokenAndSetIdentity(user, signingConfigurations, tokenConfigurations);
+                return  _signManager.GenerateTokenAndSetIdentity(result.Value, signingConfigurations, tokenConfigurations);
 
             return result;
         }

--- a/ShareBook/ShareBook.Api/Controllers/AccountController.cs
+++ b/ShareBook/ShareBook.Api/Controllers/AccountController.cs
@@ -9,7 +9,7 @@ using ShareBook.Service;
 namespace ShareBook.Api.Controllers
 {
     [Route("api/[controller]")]
-    public class AccountController : Controller
+    public class AccountController : BaseController
     {
         private readonly IUserService _userService;
         private readonly IApplicationSignInManager _signManager;

--- a/ShareBook/ShareBook.Api/Controllers/BaseController.cs
+++ b/ShareBook/ShareBook.Api/Controllers/BaseController.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using ShareBook.Api.Filters;
+
+namespace ShareBook.Api.Controllers
+{
+    [GetClaimsFilter]
+    public class BaseController : Controller
+    {
+    }
+}

--- a/ShareBook/ShareBook.Api/Controllers/BookController.cs
+++ b/ShareBook/ShareBook.Api/Controllers/BookController.cs
@@ -7,7 +7,7 @@ using ShareBook.Service;
 namespace ShareBook.Api.Controllers
 {
     [Route("api/[controller]")]
-    public class BookController : Controller
+    public class BookController : BaseController
     {
         private readonly IBookService _bookService;
 

--- a/ShareBook/ShareBook.Api/Filters/GetClaimsFilter.cs
+++ b/ShareBook/ShareBook.Api/Filters/GetClaimsFilter.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Mvc.Filters;
+using System.Threading;
+
+namespace ShareBook.Api.Filters
+{
+    public class GetClaimsFilterAttribute : ActionFilterAttribute
+    {
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            Thread.CurrentPrincipal = context.HttpContext.User;
+            base.OnActionExecuting(context);
+        }
+    }
+}

--- a/ShareBook/ShareBook.Api/Startup.cs
+++ b/ShareBook/ShareBook.Api/Startup.cs
@@ -7,6 +7,8 @@ using ShareBook.Api.AutoMapper;
 using ShareBook.Api.Configuration;
 using ShareBook.Repository;
 using Swashbuckle.AspNetCore.Swagger;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace ShareBook.Api
 {
@@ -27,12 +29,22 @@ namespace ShareBook.Api
             AutoMapperConfig.RegisterMappings();
 
             services.AddMvc();
-			
+
             JWTConfig.RegisterJWT(services, Configuration);
 
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc("v1", new Info { Title = "SHAREBOOK API", Version = "v1" });
+                c.AddSecurityDefinition("Bearer", new ApiKeyScheme
+                {
+                    Description = "JWT Authorization header using the Bearer scheme. Example: \"Authorization: Bearer {token}\"",
+                    Name = "Authorization",
+                    In = "header",
+                    Type = "apiKey"
+                });
+                c.AddSecurityRequirement(new Dictionary<string, IEnumerable<string>> {
+                    { "Bearer", Enumerable.Empty<string>() },
+                });
             });
 
             services.AddDbContext<ApplicationDbContext>(options => options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));
@@ -57,7 +69,7 @@ namespace ShareBook.Api
 
             using (var serviceScope = app.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope())
             {
-                var context = serviceScope.ServiceProvider.GetService <ApplicationDbContext> ();
+                var context = serviceScope.ServiceProvider.GetService<ApplicationDbContext>();
                 context.Database.Migrate();
             }
 

--- a/ShareBook/ShareBook.Domain/Book.cs
+++ b/ShareBook/ShareBook.Domain/Book.cs
@@ -1,10 +1,9 @@
-﻿using System;
+﻿using ShareBook.Domain.Common;
 
 namespace ShareBook.Domain
 {
-    public class Book
+    public class Book : BaseEntity
     {
-        public Guid Id { get; set; }
         public string Name { get; set; }
     }
 }

--- a/ShareBook/ShareBook.Domain/Common/BaseEntity.cs
+++ b/ShareBook/ShareBook.Domain/Common/BaseEntity.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace ShareBook.Domain.Common
+{
+    public abstract class BaseEntity
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/ShareBook/ShareBook.Domain/LogEntry.cs
+++ b/ShareBook/ShareBook.Domain/LogEntry.cs
@@ -1,0 +1,18 @@
+﻿using ShareBook.Domain.Common;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ShareBook.Domain
+{
+    public class LogEntry : BaseEntity
+    {
+        public Guid UserId { get; set; }
+        public string EntityName { get; set; }
+        public Guid EntityId { get; set; }
+        public string Operation { get; set; }
+        public DateTime LogDateTime { get; set; }
+        public string OriginalValues { get; set; }
+        public string UpdatedValues { get; set; }
+    }
+}

--- a/ShareBook/ShareBook.Domain/LogEntry.cs
+++ b/ShareBook/ShareBook.Domain/LogEntry.cs
@@ -7,7 +7,7 @@ namespace ShareBook.Domain
 {
     public class LogEntry : BaseEntity
     {
-        public Guid UserId { get; set; }
+        public Guid? UserId { get; set; }
         public string EntityName { get; set; }
         public Guid EntityId { get; set; }
         public string Operation { get; set; }

--- a/ShareBook/ShareBook.Domain/User.cs
+++ b/ShareBook/ShareBook.Domain/User.cs
@@ -1,10 +1,9 @@
-﻿using System;
+﻿using ShareBook.Domain.Common;
 
 namespace ShareBook.Domain
 {
-    public class User
+    public class User : BaseEntity
     {
-        public Guid Id { get; set; }
         public string Email { get; set; }
         public string Password { get; set; }
         public string PasswordSalt { get; set; }

--- a/ShareBook/ShareBook.Repository/ApplicationDbContext.cs
+++ b/ShareBook/ShareBook.Repository/ApplicationDbContext.cs
@@ -1,16 +1,25 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using ShareBook.Domain;
+using ShareBook.Domain.Common;
 using ShareBook.Repository.Mapping;
 
 namespace ShareBook.Repository
 {
     public class ApplicationDbContext : DbContext
     {
+        private readonly List<EntityState> entityStates = new List<EntityState>() { EntityState.Added, EntityState.Modified, EntityState.Deleted };
+
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) { }
         public ApplicationDbContext() { }
 
         public DbSet<Book> Books { get; set; }
         public DbSet<User> Users { get; set; }
+        public DbSet<LogEntry> LogEntries { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -18,6 +27,27 @@ namespace ShareBook.Repository
 
             new BookMap(modelBuilder.Entity<Book>());
             new UserMap(modelBuilder.Entity<User>());
+        }
+
+        public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var logTime = DateTime.Now;
+            var changes = ChangeTracker.Entries()
+                .Where(x => entityStates.Contains(x.State) && x.Entity.GetType().IsSubclassOf(typeof(BaseEntity)))
+                .Select(t => new LogEntry()
+                {
+                    EntityName = t.Entity.GetType().Name,
+                    EntityId = new Guid(t.CurrentValues["Id"].ToString()),
+                    LogDateTime = logTime,
+                    Operation = t.State.ToString(),
+                    OriginalValues = string.Join("\n", t.OriginalValues.Properties.ToDictionary(pn => pn.Name, pn => t.OriginalValues[pn])),
+                    UpdatedValues = string.Join("\n", t.CurrentValues.Properties.ToDictionary(pn => pn.Name, pn => t.CurrentValues[pn])),
+                })
+                .ToList();
+
+            LogEntries.AddRange(changes);
+
+            return base.SaveChangesAsync(cancellationToken);
         }
     }
 }

--- a/ShareBook/ShareBook.Repository/ApplicationDbContext.cs
+++ b/ShareBook/ShareBook.Repository/ApplicationDbContext.cs
@@ -12,8 +12,6 @@ namespace ShareBook.Repository
 {
     public class ApplicationDbContext : DbContext
     {
-        private readonly List<EntityState> entityStates = new List<EntityState>() { EntityState.Added, EntityState.Modified, EntityState.Deleted };
-
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) { }
         public ApplicationDbContext() { }
 
@@ -31,28 +29,7 @@ namespace ShareBook.Repository
 
         public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            var logTime = DateTime.Now;
-
-            Guid? user = null;
-            if (!string.IsNullOrEmpty(Thread.CurrentPrincipal?.Identity?.Name))
-                user = new Guid(Thread.CurrentPrincipal?.Identity?.Name);
-
-            var changes = ChangeTracker.Entries()
-                .Where(x => entityStates.Contains(x.State) && x.Entity.GetType().IsSubclassOf(typeof(BaseEntity)))
-                .Select(t => new LogEntry()
-                {
-                    EntityName = t.Entity.GetType().Name,
-                    EntityId = new Guid(t.CurrentValues["Id"].ToString()),
-                    LogDateTime = logTime,
-                    Operation = t.State.ToString(),
-                    UserId = user,
-                    OriginalValues = string.Join("\n", t.OriginalValues.Properties.ToDictionary(pn => pn.Name, pn => t.OriginalValues[pn])),
-                    UpdatedValues = string.Join("\n", t.CurrentValues.Properties.ToDictionary(pn => pn.Name, pn => t.CurrentValues[pn])),
-                })
-                .ToList();
-
-            LogEntries.AddRange(changes);
-
+            this.LogChanges();
             return base.SaveChangesAsync(cancellationToken);
         }
     }

--- a/ShareBook/ShareBook.Repository/ApplicationDbContext.cs
+++ b/ShareBook/ShareBook.Repository/ApplicationDbContext.cs
@@ -33,7 +33,7 @@ namespace ShareBook.Repository
         {
             var logTime = DateTime.Now;
 
-            var user = new Guid();
+            Guid? user = null;
             if (!string.IsNullOrEmpty(Thread.CurrentPrincipal?.Identity?.Name))
                 user = new Guid(Thread.CurrentPrincipal?.Identity?.Name);
 

--- a/ShareBook/ShareBook.Repository/ApplicationDbContext.cs
+++ b/ShareBook/ShareBook.Repository/ApplicationDbContext.cs
@@ -32,6 +32,11 @@ namespace ShareBook.Repository
         public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             var logTime = DateTime.Now;
+
+            var user = new Guid();
+            if (!string.IsNullOrEmpty(Thread.CurrentPrincipal?.Identity?.Name))
+                user = new Guid(Thread.CurrentPrincipal?.Identity?.Name);
+
             var changes = ChangeTracker.Entries()
                 .Where(x => entityStates.Contains(x.State) && x.Entity.GetType().IsSubclassOf(typeof(BaseEntity)))
                 .Select(t => new LogEntry()
@@ -40,6 +45,7 @@ namespace ShareBook.Repository
                     EntityId = new Guid(t.CurrentValues["Id"].ToString()),
                     LogDateTime = logTime,
                     Operation = t.State.ToString(),
+                    UserId = user,
                     OriginalValues = string.Join("\n", t.OriginalValues.Properties.ToDictionary(pn => pn.Name, pn => t.OriginalValues[pn])),
                     UpdatedValues = string.Join("\n", t.CurrentValues.Properties.ToDictionary(pn => pn.Name, pn => t.CurrentValues[pn])),
                 })

--- a/ShareBook/ShareBook.Repository/Infra/CrossCutting/Identity/ApplicationSignInManager.cs
+++ b/ShareBook/ShareBook.Repository/Infra/CrossCutting/Identity/ApplicationSignInManager.cs
@@ -13,7 +13,6 @@ namespace ShareBook.Repository.Infra.CrossCutting.Identity.Configurations
         public object GenerateTokenAndSetIdentity(User user, SigningConfigurations signingConfigurations, TokenConfigurations tokenConfigurations)
         {
             ClaimsIdentity identity = new ClaimsIdentity(
-                    new GenericIdentity(user.Id.ToString()),
                     new[] {
                         new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString("N")),
                         new Claim(JwtRegisteredClaimNames.UniqueName, user.Id.ToString())

--- a/ShareBook/ShareBook.Repository/LoggingContext.cs
+++ b/ShareBook/ShareBook.Repository/LoggingContext.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore;
+using ShareBook.Domain;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace ShareBook.Repository
+{
+    public static class LoggingContext
+    {
+        private static readonly List<EntityState> entityStates = new List<EntityState>() { EntityState.Added, EntityState.Modified, EntityState.Deleted };
+
+        public static void LogChanges(this ApplicationDbContext context)
+        {
+            var logTime = DateTime.Now;
+
+            Guid? user = null;
+            if (!string.IsNullOrEmpty(Thread.CurrentPrincipal?.Identity?.Name))
+                user = new Guid(Thread.CurrentPrincipal?.Identity?.Name);
+
+            var changes = context.ChangeTracker.Entries()
+                .Where(x => entityStates.Contains(x.State) && x.Entity.GetType().IsSubclassOf(typeof(BaseEntity)))
+                .Select(t => new LogEntry()
+                {
+                    EntityName = t.Entity.GetType().Name,
+                    EntityId = new Guid(t.CurrentValues["Id"].ToString()),
+                    LogDateTime = logTime,
+                    Operation = t.State.ToString(),
+                    UserId = user,
+                    OriginalValues = string.Join("\n", t.OriginalValues.Properties.ToDictionary(pn => pn.Name, pn => t.OriginalValues[pn])),
+                    UpdatedValues = string.Join("\n", t.CurrentValues.Properties.ToDictionary(pn => pn.Name, pn => t.CurrentValues[pn])),
+                })
+                .ToList();
+
+            context.LogEntries.AddRange(changes);
+        }
+    }
+}

--- a/ShareBook/ShareBook.Repository/Mapping/LogEntryMap.cs
+++ b/ShareBook/ShareBook.Repository/Mapping/LogEntryMap.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using ShareBook.Domain;
+
+namespace ShareBook.Repository.Mapping
+{
+    public class LogEntryMap
+    {
+        public LogEntryMap(EntityTypeBuilder<LogEntry> entityBuilder)
+        {
+            entityBuilder.HasKey(t => t.Id);
+            entityBuilder.Property(t => t.UserId);
+            entityBuilder.Property(t => t.EntityName);
+            entityBuilder.Property(t => t.EntityId);
+            entityBuilder.Property(t => t.Operation);
+            entityBuilder.Property(t => t.LogDateTime);
+            entityBuilder.Property(t => t.OriginalValues);
+            entityBuilder.Property(t => t.UpdatedValues);
+        }
+    }
+}

--- a/ShareBook/ShareBook.Repository/Migrations/20180528120526_AddLogEntries.Designer.cs
+++ b/ShareBook/ShareBook.Repository/Migrations/20180528120526_AddLogEntries.Designer.cs
@@ -11,9 +11,10 @@ using System;
 namespace ShareBook.Repository.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180528120526_AddLogEntries")]
+    partial class AddLogEntries
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ShareBook/ShareBook.Repository/Migrations/20180528120526_AddLogEntries.cs
+++ b/ShareBook/ShareBook.Repository/Migrations/20180528120526_AddLogEntries.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+using System.Collections.Generic;
+
+namespace ShareBook.Repository.Migrations
+{
+    public partial class AddLogEntries : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LogEntries",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(nullable: false),
+                    EntityId = table.Column<Guid>(nullable: false),
+                    EntityName = table.Column<string>(nullable: true),
+                    LogDateTime = table.Column<DateTime>(nullable: false),
+                    Operation = table.Column<string>(nullable: true),
+                    OriginalValues = table.Column<string>(nullable: true),
+                    UpdatedValues = table.Column<string>(nullable: true),
+                    UserId = table.Column<Guid>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LogEntries", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LogEntries");
+        }
+    }
+}

--- a/ShareBook/ShareBook.Repository/Migrations/20180528134226_ChangeLogEntries_UserIdNull.Designer.cs
+++ b/ShareBook/ShareBook.Repository/Migrations/20180528134226_ChangeLogEntries_UserIdNull.Designer.cs
@@ -11,9 +11,10 @@ using System;
 namespace ShareBook.Repository.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180528134226_ChangeLogEntries_UserIdNull")]
+    partial class ChangeLogEntries_UserIdNull
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ShareBook/ShareBook.Repository/Migrations/20180528134226_ChangeLogEntries_UserIdNull.cs
+++ b/ShareBook/ShareBook.Repository/Migrations/20180528134226_ChangeLogEntries_UserIdNull.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+using System.Collections.Generic;
+
+namespace ShareBook.Repository.Migrations
+{
+    public partial class ChangeLogEntries_UserIdNull : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "UserId",
+                table: "LogEntries",
+                nullable: true,
+                oldClrType: typeof(Guid));
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "UserId",
+                table: "LogEntries",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldNullable: true);
+        }
+    }
+}


### PR DESCRIPTION
Agora as entidades devem herdar da BaseEntity. Dessa forma, a propriedade ID não é mais necessária de ser colocada na entidade.
Toda vez que rolar um SaveChanges a aplicação irá verificar todas as entidades inseridas, modificadas ou excluídas e irá gerar um log com a informação.
Os controllers devem herdar do BaseController. Hoje, ele só define um Filter que irá colocar o usuário do token na Thread.
Caso o CRUD seja executado por um usuário logado, o log irá registrar a alteração sob aquele usuário. Caso contrário, irá inserir null no campo.