### PR TITLE
Criando mecanismo para senha forte

### DIFF
--- a/ShareBook/ShareBook.Domain/User.cs
+++ b/ShareBook/ShareBook.Domain/User.cs
@@ -17,7 +17,7 @@ namespace ShareBook.Domain
         public Profile Profile { get;  set; } = Profile.User;
         public virtual ICollection<BookUser> BookUsers { get; set; }
 
-        public bool PasswordIsValid()
+        public bool PasswordIsStrong()
         {
             Regex rgx = new Regex(@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^\da-zA-Z]).{8,15}$");
             if (string.IsNullOrEmpty(Password) || !rgx.IsMatch(Password)) return false;

--- a/ShareBook/ShareBook.Domain/User.cs
+++ b/ShareBook/ShareBook.Domain/User.cs
@@ -1,6 +1,7 @@
 ﻿using ShareBook.Domain.Common;
 using ShareBook.Domain.Enums;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace ShareBook.Domain
 {
@@ -15,6 +16,14 @@ namespace ShareBook.Domain
         public  string Phone{ get; set; }
         public Profile Profile { get;  set; } = Profile.User;
         public virtual ICollection<BookUser> BookUsers { get; set; }
+
+        public bool PasswordIsValid()
+        {
+            Regex rgx = new Regex(@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^\da-zA-Z]).{8,15}$");
+            if (string.IsNullOrEmpty(Password) || !rgx.IsMatch(Password)) return false;
+
+            return true;
+        }
 
         public void ChangeEmail(string email)
         {

--- a/ShareBook/ShareBook.Service/User/UserService.cs
+++ b/ShareBook/ShareBook.Service/User/UserService.cs
@@ -46,8 +46,10 @@ namespace ShareBook.Service
 
         public override Result<User> Insert(User user)
         {
-
             var result = Validate(user);
+
+            if(!user.PasswordIsValid())
+                result.Messages.Add("A senha não atende os requisitos. Minimo oito caracteres, um caracter especial, um caracter númerico e uma letra em maíusculo.");
 
             if (_repository.Any(x => x.Email == user.Email))
                 result.Messages.Add("Usuário já possui email cadastrado.");
@@ -109,6 +111,14 @@ namespace ShareBook.Service
             {
                 var userAuth = resultUserAuth.Value;
                 userAuth.ChangePassword(newPassword);
+                
+                if(!userAuth.PasswordIsValid())
+                {
+                    resultUserAuth.Messages.Add("A senha não atende os requisitos. Minimo oito caracteres, um caracter especial, um caracter númerico e uma letra em maíusculo.");
+                    resultUserAuth.Value = null;
+                    return resultUserAuth;
+                }
+                    
                 userAuth = GetUserEncryptedPass(userAuth);
                 userAuth = _userRepository.UpdatePassword(userAuth).Result;
                 resultUserAuth.Value = UserCleanup(userAuth);

--- a/ShareBook/ShareBook.Service/User/UserService.cs
+++ b/ShareBook/ShareBook.Service/User/UserService.cs
@@ -15,6 +15,7 @@ namespace ShareBook.Service
     public class UserService : BaseService<User>, IUserService
     {
         private readonly IUserRepository _userRepository;
+        private const string PASSWORD_IS_WEAK = "A senha não atende os requisitos. Mínimo oito caracteres, um caractere especial, um caractere numérico e uma letra em maiúsculo.";
         #region Public
         public UserService(IUserRepository userRepository, IUnitOfWork unitOfWork, IValidator<User> validator) : base(userRepository, unitOfWork, validator)
         {
@@ -48,8 +49,8 @@ namespace ShareBook.Service
         {
             var result = Validate(user);
 
-            if(!user.PasswordIsValid())
-                result.Messages.Add("A senha não atende os requisitos. Minimo oito caracteres, um caracter especial, um caracter númerico e uma letra em maíusculo.");
+            if(!user.PasswordIsStrong())
+                result.Messages.Add(PASSWORD_IS_WEAK);
 
             if (_repository.Any(x => x.Email == user.Email))
                 result.Messages.Add("Usuário já possui email cadastrado.");
@@ -112,9 +113,9 @@ namespace ShareBook.Service
                 var userAuth = resultUserAuth.Value;
                 userAuth.ChangePassword(newPassword);
                 
-                if(!userAuth.PasswordIsValid())
+                if(!userAuth.PasswordIsStrong())
                 {
-                    resultUserAuth.Messages.Add("A senha não atende os requisitos. Minimo oito caracteres, um caracter especial, um caracter númerico e uma letra em maíusculo.");
+                    resultUserAuth.Messages.Add(PASSWORD_IS_WEAK);
                     resultUserAuth.Value = null;
                     return resultUserAuth;
                 }

--- a/ShareBook/ShareBook.Test.Unit/Services/UserServiceTests.cs
+++ b/ShareBook/ShareBook.Test.Unit/Services/UserServiceTests.cs
@@ -114,7 +114,7 @@ namespace ShareBook.Test.Unit.Services
             Result<User> result = service.Insert(new User()
             {
                 Email = "jose@sharebook.com",
-                Password = "123456",
+                Password = "Password.123",
                 Name = "José da Silva",
                 Linkedin = @"linkedin.com\jose-silva",
                 PostalCode = "04473-190",

--- a/ShareBook/ShareBook.Test.Unit/Validators/UserValidatorTests.cs
+++ b/ShareBook/ShareBook.Test.Unit/Validators/UserValidatorTests.cs
@@ -56,7 +56,7 @@ namespace ShareBook.Test.Unit.Validators
         {
             userPasswordTest.Password = "123456";
 
-            var result = userPasswordTest.PasswordIsValid();
+            var result = userPasswordTest.PasswordIsStrong();
 
             Assert.False(result);
         }
@@ -66,7 +66,7 @@ namespace ShareBook.Test.Unit.Validators
         {
             userPasswordTest.Password = "password";
 
-            var result = userPasswordTest.PasswordIsValid();
+            var result = userPasswordTest.PasswordIsStrong();
 
             Assert.False(result);
         }
@@ -76,7 +76,7 @@ namespace ShareBook.Test.Unit.Validators
         {
             userPasswordTest.Password = "password123";
 
-            var result = userPasswordTest.PasswordIsValid();
+            var result = userPasswordTest.PasswordIsStrong();
 
             Assert.False(result);
         }
@@ -86,7 +86,7 @@ namespace ShareBook.Test.Unit.Validators
         {
             userPasswordTest.Password = "password.123";
 
-            var result = userPasswordTest.PasswordIsValid();
+            var result = userPasswordTest.PasswordIsStrong();
 
             Assert.False(result);
         }
@@ -96,7 +96,7 @@ namespace ShareBook.Test.Unit.Validators
         {
             userPasswordTest.Password =  "Password.123";
 
-            var result = userPasswordTest.PasswordIsValid();
+            var result = userPasswordTest.PasswordIsStrong();
 
             Assert.True(result);
         }

--- a/ShareBook/ShareBook.Test.Unit/Validators/UserValidatorTests.cs
+++ b/ShareBook/ShareBook.Test.Unit/Validators/UserValidatorTests.cs
@@ -7,7 +7,15 @@ namespace ShareBook.Test.Unit.Validators
 {
     public class UserValidatorTests
     {
-        UserValidator userValidation = new UserValidator();
+        UserValidator userValidation;
+        User userPasswordTest;
+
+        public UserValidatorTests()
+        {
+            userValidation = new UserValidator();
+            userPasswordTest = new User();
+
+        }
 
         [Fact]
         public void ValidEntities()
@@ -15,7 +23,7 @@ namespace ShareBook.Test.Unit.Validators
 			User user = new User()
 			{
 				Email = "joão@sharebook.com",
-				Password = "password",
+				Password = "Password.123",
 				Name = "João da Silva",
 				Linkedin = "linkedin.com/joao-silva",
                 PostalCode = "04473-190"
@@ -41,6 +49,56 @@ namespace ShareBook.Test.Unit.Validators
             ValidationResult result = userValidation.Validate(user);
 
             Assert.False(result.IsValid);
+        }
+
+        [Fact]
+        public void PasswordOnlyNumbers()
+        {
+            userPasswordTest.Password = "123456";
+
+            var result = userPasswordTest.PasswordIsValid();
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void PasswordOnlyLetters()
+        {
+            userPasswordTest.Password = "password";
+
+            var result = userPasswordTest.PasswordIsValid();
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void PasswordLettersNumbers()
+        {
+            userPasswordTest.Password = "password123";
+
+            var result = userPasswordTest.PasswordIsValid();
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void PasswordSpecialCharacter()
+        {
+            userPasswordTest.Password = "password.123";
+
+            var result = userPasswordTest.PasswordIsValid();
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void PasswordValid()
+        {
+            userPasswordTest.Password =  "Password.123";
+
+            var result = userPasswordTest.PasswordIsValid();
+
+            Assert.True(result);
         }
     }
 }


### PR DESCRIPTION
Não aceitar senhas "fracas".

critérios de aceite.

- deve ter pelo menos um caracter UPPERCASE.
- deve ter no mínimo 8 caracteres;
- deve ter pelo menos um caracter numérico.